### PR TITLE
Adds ignoreLinePatterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,19 @@ You can configure your own colors by adding and tampering with the following cod
     "rgba(16,48,48,0.3)",
     "rgba(128,32,32,0.3)"
   ]
-  
+
   // The indent color if the number of spaces is not a multiple of "tabSize".
   "indentRainbow.error_color": "rgba(128,32,32,0.3)"
+```
+
+Skip error highlighting for RegEx patterns. For example, you may want to turn off the indent errors for JSDoc's valid additional space (disabled by default), or comment lines beginning with `//`
+
+```
+  // Example of regular expression in JSON (note double backslash to escape characters)
+  "indentRainbow.ignoreLinePatterns" : [
+    "/.*\\*.*/mg", // lines begining wit *
+    "/.*\\/\\/.*/g" // lines begininning with //
+  ]
 ```
 
 The following is experimental and still buggy. It will basically disable the automatic detection for languages which are not defined in this array. You may not want to use it at all :)

--- a/package.json
+++ b/package.json
@@ -54,6 +54,13 @@
                     "default": "rgba(128,32,32,0.6)",
                     "description": "Indent color for when there is an error in the indentation, for example if you have your tabs set to 2 spaces but the indent is 3 spaces. Can be any type of web based color format (hex, rgba, rgb)."
                 },
+                "indentRainbow.ignoreLinePatterns": {
+                    "type": "array",
+                    "default": [
+                        "/.*\\*.*/g"
+                    ],
+                    "description": "Skip error highlighting for RegEx patterns. Defaults to ignoring JSDoc comments with a single extra space."
+                },
                 "indentRainbow.colors": {
                     "type": "array",
                     "default": [

--- a/tests/5_jsdoc_indent.js
+++ b/tests/5_jsdoc_indent.js
@@ -1,0 +1,23 @@
+/**
+ * Should ignore JSDoc extra indent.
+ * @class testClass
+ *
+ */
+class testClass {
+    constructor(param) {
+
+    }
+
+    /**
+     * JSDoc with more index.
+     *  should ignore errors and still show high-level indent
+     * @memberof testClass
+     */
+    test() {
+        //
+    }
+     error() {
+     //   this should contain indent errors
+     // ignore // lines
+     }
+}


### PR DESCRIPTION
Addresses #17 JSDoc shown as an error.
Adds a RegEx configuration to ignore lines containing the matched regular expression.

Skips indent error highlighting on defined regular expressions.
- Ignores JSDoc style lines by default; lines beginning with `*`