### PR TITLE
Update default colors to be just as subtle on light themes

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -34,10 +34,10 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Colors will cycle through, and can be any size that you want
   const colors = vscode.workspace.getConfiguration('indentRainbow')['colors'] || [
-    "rgba(64,64,16,0.3)",
-    "rgba(32,64,32,0.3)",
-    "rgba(64,32,64,0.3)",
-    "rgba(16,48,48,0.3)"
+    "rgba(255,255,64,0.07)",
+    "rgba(127,255,127,0.07)",
+    "rgba(255,127,255,0.07)",
+    "rgba(79,236,236,0.07)"
   ];
 
   // Loops through colors and creates decoration types for each one

--- a/package.json
+++ b/package.json
@@ -76,10 +76,10 @@
                 "indentRainbow.colors": {
                     "type": "array",
                     "default": [
-                        "rgba(64,64,16,0.3)",
-                        "rgba(32,64,32,0.3)",
-                        "rgba(64,32,64,0.3)",
-                        "rgba(16,48,48,0.3)"
+                        "rgba(255,255,64,0.07)",
+                        "rgba(127,255,127,0.07)",
+                        "rgba(255,127,255,0.07)",
+                        "rgba(79,236,236,0.07)"
                     ],
                     "description": "An array with color (hex, rgba, rgb) strings which are used as colors, can be any length."
                 }


### PR DESCRIPTION
The new colors look almost identical on dark themes, but they have less opacity and less "darkness", which makes them look a lot better on light themes.

I was too lazy to compute the colors that would produce exactly the same resulting color on dark themes, so I just kind of eyeballed it. I feel like this is close enough:

| Before     | After     |
| ---------- | --------- |
| ![before1] | ![after1] |
| ![before2] | ![after2] |


[before1]: https://user-images.githubusercontent.com/1570168/52378107-ab6c5d00-2a1b-11e9-86af-aa1d5bc97b86.png
[before2]: https://user-images.githubusercontent.com/1570168/52378097-a4dde580-2a1b-11e9-91f1-0c2e3ca8a62a.png

[after1]: https://user-images.githubusercontent.com/1570168/52378043-7d871880-2a1b-11e9-80d7-b343ea43d671.png
[after2]: https://user-images.githubusercontent.com/1570168/52378063-88da4400-2a1b-11e9-98fa-3b92f31ff1f5.png
