### PR TITLE
Fix/prettier compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,65 @@
             "type": "object",
             "title": "Indent-Rainbow configuration",
             "properties": {
+                "indentRainbow": {
+                    "includedLanguages": {
+                        "type": "array",
+                        "default": [],
+                        "description": "For which languages indent-rainbow should be activated. When empty will use for all languages."
+                    },
+                    "excludedLanguages": {
+                        "type": "array",
+                        "default": [
+                            "plaintext"
+                        ],
+                        "description": "For which languages indent-rainbow should be deactivated. When left empty will ignore."
+                    },
+                    "ignoreErrorLanguages": {
+                        "type": "array",
+                        "default": [
+                            "markdown"
+                        ],
+                        "description": "For which languages indent-rainbow should skip indent error detection (use '*' to deavtivate errors for all languages)."
+                    },
+                    "updateDelay": {
+                        "type": "integer",
+                        "default": 100,
+                        "description": "The delay in ms until the editor gets updated."
+                    },
+                    "indentSetter": {
+                        "type": "object",
+                        "default": {},
+                        "description": "Automatically change indent settings for languages (see README.md for details)."
+                    },
+                    "errorColor": {
+                        "type": "string",
+                        "default": "rgba(128,32,32,0.6)",
+                        "description": "Indent color for when there is an error in the indentation, for example if you have your tabs set to 2 spaces but the indent is 3 spaces. Can be any type of web based color format (hex, rgba, rgb)."
+                    },
+                    "tabmixColor": {
+                        "type": "string",
+                        "default": "rgba(128,32,96,0.6)",
+                        "description": "Indent color for when there is a mix between spaces and tabs in the indentation. Can be any type of web based color format (hex, rgba, rgb) or a empty string(to be disabled this coloring)."
+                    },
+                    "ignoreLinePatterns": {
+                        "type": "array",
+                        "default": [
+                            "/[ \t]* [*]/g",
+                            "/[ \t]+[/]{2}/g"
+                        ],
+                        "description": "Skip error highlighting for RegEx patterns. Defaults to c/cpp decorated block and full line comments."
+                    },
+                    "colors": {
+                        "type": "array",
+                        "default": [
+                            "rgba(255,255,64,0.07)",
+                            "rgba(127,255,127,0.07)",
+                            "rgba(255,127,255,0.07)",
+                            "rgba(79,236,236,0.07)"
+                        ],
+                        "description": "An array with color (hex, rgba, rgb) strings which are used as colors, can be any length."
+                    }
+                },
                 "indentRainbow.includedLanguages": {
                     "type": "array",
                     "default": [],

--- a/package.json
+++ b/package.json
@@ -29,65 +29,6 @@
             "type": "object",
             "title": "Indent-Rainbow configuration",
             "properties": {
-                "indentRainbow": {
-                    "includedLanguages": {
-                        "type": "array",
-                        "default": [],
-                        "description": "For which languages indent-rainbow should be activated. When empty will use for all languages."
-                    },
-                    "excludedLanguages": {
-                        "type": "array",
-                        "default": [
-                            "plaintext"
-                        ],
-                        "description": "For which languages indent-rainbow should be deactivated. When left empty will ignore."
-                    },
-                    "ignoreErrorLanguages": {
-                        "type": "array",
-                        "default": [
-                            "markdown"
-                        ],
-                        "description": "For which languages indent-rainbow should skip indent error detection (use '*' to deavtivate errors for all languages)."
-                    },
-                    "updateDelay": {
-                        "type": "integer",
-                        "default": 100,
-                        "description": "The delay in ms until the editor gets updated."
-                    },
-                    "indentSetter": {
-                        "type": "object",
-                        "default": {},
-                        "description": "Automatically change indent settings for languages (see README.md for details)."
-                    },
-                    "errorColor": {
-                        "type": "string",
-                        "default": "rgba(128,32,32,0.6)",
-                        "description": "Indent color for when there is an error in the indentation, for example if you have your tabs set to 2 spaces but the indent is 3 spaces. Can be any type of web based color format (hex, rgba, rgb)."
-                    },
-                    "tabmixColor": {
-                        "type": "string",
-                        "default": "rgba(128,32,96,0.6)",
-                        "description": "Indent color for when there is a mix between spaces and tabs in the indentation. Can be any type of web based color format (hex, rgba, rgb) or a empty string(to be disabled this coloring)."
-                    },
-                    "ignoreLinePatterns": {
-                        "type": "array",
-                        "default": [
-                            "/[ \t]* [*]/g",
-                            "/[ \t]+[/]{2}/g"
-                        ],
-                        "description": "Skip error highlighting for RegEx patterns. Defaults to c/cpp decorated block and full line comments."
-                    },
-                    "colors": {
-                        "type": "array",
-                        "default": [
-                            "rgba(255,255,64,0.07)",
-                            "rgba(127,255,127,0.07)",
-                            "rgba(255,127,255,0.07)",
-                            "rgba(79,236,236,0.07)"
-                        ],
-                        "description": "An array with color (hex, rgba, rgb) strings which are used as colors, can be any length."
-                    }
-                },
                 "indentRainbow.includedLanguages": {
                     "type": "array",
                     "default": [],

--- a/tests/6_mixed_indent.js
+++ b/tests/6_mixed_indent.js
@@ -1,0 +1,7 @@
+test
+  2 spaces
+  we do 2 space indents
+    and even 2 more
+    or
+  less again
+	  mixed

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,7 @@
 		"no-unused-variable": true,
 		"curly": true,
 		"class-name": true,
-		"semicolon": ["always"],
+		"semicolon": [true, "always"],
 		"triple-equals": true
 	}
 }


### PR DESCRIPTION
This fixed issues discussed on #56.
User will still be required to ignored language(s) but the highlight will no longer overlap the text.

Before:
![image](https://user-images.githubusercontent.com/5505621/88454019-d924ac00-ce31-11ea-8407-20bb511d69a4.png)

After:
![image](https://user-images.githubusercontent.com/5505621/88454003-be523780-ce31-11ea-9404-a19686055efa.png)

I did some refactoring which was essential for me to understand the code, if you feel like that's too much let me know and I can try to back it out and have the least changes possible.