### PR TITLE
Run on line errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ Although you can just use it as it is there is the possibility to configure some
   "indentRainbow.excludedLanguages": ["plaintext"]
 
   // The delay in ms until the editor gets updated.
-  "indentRainbow.updateDelay": 100 // 10 makes it super fast but may cost more resources
+  "indentRainbow.updateDelay": 100 // 10 makes it super fast but may cost more resources,
+
+  // Do not show an error when the indent lines up with a bracket on a previous line.
+  "indentRainbow.allowAligningToBrackets": false
 ```
 
 *Notice: Defining both `includedLanguages` and `excludedLanguages` does not make much sense. Use one of both!*

--- a/extension.ts
+++ b/extension.ts
@@ -187,7 +187,7 @@ export function activate(context: vscode.ExtensionContext) {
     let defaultIndentCharRegExp = null;
 
     while (match = regEx.exec(text)) {
-      const pos = activeEditor.document.positionAt(ignore.index);
+      const pos = activeEditor.document.positionAt(match.index);
       const line = activeEditor.document.lineAt(pos).lineNumber;
       let skip = skipAllErrors || ignoreLines.indexOf(line) !== -1; // true if the lineNumber is in ignoreLines.
       var thematch = match[0];

--- a/extension.ts
+++ b/extension.ts
@@ -29,6 +29,8 @@ export function activate(context: vscode.ExtensionContext) {
 
   const ignoreLinePatterns = vscode.workspace.getConfiguration('indentRainbow')['ignoreLinePatterns'] || [];
 
+  const allowAligningToBrackets = vscode.workspace.getConfiguration('indentRainbow')['allowAligningToBrackets'] || false;
+
   // Colors will cycle through, and can be any size that you want
   const colors = vscode.workspace.getConfiguration('indentRainbow')['colors'] || [
     "rgba(255,255,64,0.07)",
@@ -185,8 +187,7 @@ export function activate(context: vscode.ExtensionContext) {
     let defaultIndentCharRegExp = null;
 
     while (match = regEx.exec(text)) {
-      const pos = activeEditor.document.positionAt(match.index);
-      const line = activeEditor.document.lineAt(pos).lineNumber;
+      const line = activeEditor.document.positionAt(match.index).line;
       let skip = skipAllErrors || ignoreLines.indexOf(line) !== -1; // true if the lineNumber is in ignoreLines.
       var thematch = match[0];
       var ma = (match[0].replace(re, tabs)).length;
@@ -194,10 +195,19 @@ export function activate(context: vscode.ExtensionContext) {
        * Error handling.
        * When the indent spacing (as spaces) is not divisible by the tabsize,
        * consider the indent incorrect and mark it with the error decorator.
-       * Checks for lines being ignored in ignoreLines array ( `skip` Boolran)
+       * Checks for lines being ignored in ignoreLines array ( `skip` Boolean)
        * before considering the line an error.
+       * Checks whether the indent lines up with the start of the text or a
+       * bracket on the previous line before considering the line an error
        */
-      if(!skip && ma % tabsize !== 0) {
+      let error = !skip && ma % tabsize !== 0;
+      if (error && allowAligningToBrackets && line > 0) {
+        let prevLn = activeEditor.document.lineAt(line - 1);
+        if (prevLn.firstNonWhitespaceCharacterIndex === ma || new RegExp("\\{|\\(|\\[|<").test(prevLn.text[ma - 1])) {
+          error = false;
+        }
+      }
+      if (error) {
         var startPos = activeEditor.document.positionAt(match.index);
         var endPos = activeEditor.document.positionAt(match.index + match[0].length);
         var decoration = { range: new vscode.Range(startPos, endPos), hoverMessage: null };

--- a/package.json
+++ b/package.json
@@ -85,6 +85,11 @@
                         "rgba(79,236,236,0.07)"
                     ],
                     "description": "An array with color (hex, rgba, rgb) strings which are used as colors, can be any length."
+                },
+                "indentRainbow.allowAligningToBrackets": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Do not show an error when the indent lines up with a bracket on a previous line."
                 }
             }
         }

--- a/tests/6_run_on_indent.cpp
+++ b/tests/6_run_on_indent.cpp
@@ -1,19 +1,20 @@
-
 #include <string>
 #include <map>
 #include <vector>
 
 /*
  * Weeeeee comments
+ *
  */
 const int myVeryLongFunctionNameWhichWillGoOnForever(const std::map<std::string, std::string> &longParamOne,
                                                      const std::map<std::string, std::string> &longParamTwo,
-                                                     const std::map<std::string, std::string> &longParamThree)
+                                                     const std::map<std::string, std::string> &longParamThree,
+                                                       const std::map<std::string, std::string> *longParamFour)
 {
     int currentReturnCode = 0;
     int returnCodeOk = 0;
-    if (!(currentReturnCode == returnCodeOk || longParamOne.find("A nice longs test string boop")->second == "test" ||
-          longParamTwo.find("A nice longs test string boop")->second == "test"))
+    if (!(currentReturnCode == returnCodeOk || longParamOne.find("A nice long test string boop")->second == "test" ||
+          longParamTwo.find("A nice long test string boop")->second == "test"))
     {
         currentReturnCode = anotherVeryLongFunctionNameWhichReallyHasNoBuisnessBeingThisLong(currentReturnCode,
                                                                                              returnCodeOk);
@@ -23,6 +24,7 @@ const int myVeryLongFunctionNameWhichWillGoOnForever(const std::map<std::string,
                                              "Test String Four", "Test String Five"};
 
      int anActualIncorrectIndent = 5;
+     int *aPointerWithABadIndent = new int(5);
     return anActualIncorrectIndent;
 }
 

--- a/tests/6_run_on_indent.cpp
+++ b/tests/6_run_on_indent.cpp
@@ -1,0 +1,32 @@
+
+#include <string>
+#include <map>
+#include <vector>
+
+/*
+ * Weeeeee comments
+ */
+const int myVeryLongFunctionNameWhichWillGoOnForever(const std::map<std::string, std::string> &longParamOne,
+                                                     const std::map<std::string, std::string> &longParamTwo,
+                                                     const std::map<std::string, std::string> &longParamThree)
+{
+    int currentReturnCode = 0;
+    int returnCodeOk = 0;
+    if (!(currentReturnCode == returnCodeOk || longParamOne.find("A nice longs test string boop")->second == "test" ||
+          longParamTwo.find("A nice longs test string boop")->second == "test"))
+    {
+        currentReturnCode = anotherVeryLongFunctionNameWhichReallyHasNoBuisnessBeingThisLong(currentReturnCode,
+                                                                                             returnCodeOk);
+    }
+
+    std::vector<std::string> aLongVectorList{"Test String One", "Test String Two", "Test String Three",
+                                             "Test String Four", "Test String Five"};
+
+     int anActualIncorrectIndent = 5;
+    return anActualIncorrectIndent;
+}
+
+const int anotherVeryLongFunctionNameWhichReallyHasNoBuisnessBeingThisLong(int itemOne, int itemTwo)
+{
+    return 0;
+}


### PR DESCRIPTION
In some languages overly long lines are split up and the indent rules aren't strictly a multiple of 4 or whatever. Added an option to align to a bracket in a previous line.

Works by doing the same error check as before. If a line has an error search the previous lines to see if there's an open bracket ({[< it's aligning to.

Before:
![2020-07-31 12_40_57- Extension Development Host  - tests - 6_run_on_indent cpp](https://user-images.githubusercontent.com/26423544/89032527-c6780e80-d32c-11ea-8289-75b82b13742a.png)

After:
![2020-07-31 12_45_30- Extension Development Host  - tests - 6_run_on_indent cpp](https://user-images.githubusercontent.com/26423544/89032537-c8da6880-d32c-11ea-8235-ac2c79b07d04.png)
