### PR TITLE
Update package.json{.main} to reflect movement of ./extension.ts to ./src/extension.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         }
     },
     "browser": "./dist/web/extension.js",
-    "main": "./out/extension",
+    "main": "./out/src/extension",
     "scripts": {
         "vscode:prepublish": "npm run compile && npm run package-web",
         "compile": "tsc -p ./",


### PR DESCRIPTION
|                             | 7.4.0                                    | 7.5.0                                    |
|-----------------------------|------------------------------------------|------------------------------------------|
| Commit                      | a8c564d49f06230e628f1b5087910968be268301 | d22d79230dfa7e6a30947a3195fdba93ea66cfde |
| Source Location             | ./extension.ts                           | ./src/extension.ts                       |
| Compiled Output Destination | ./out/extension.js                       | ./out/src/extension.js                   |
| Package.json `main`         | ./out/extension                          | ./out/extension (!)                      |

`package.json{.main}` points to `./out/extension`, but this path no longer exists. This PR updates it to the new existing path. This causes the extension to once again load in code-oss/vscodium, fixing https://github.com/oderwat/vscode-indent-rainbow/issues/100