### PR TITLE
Add light style

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,17 @@
                     "type": "boolean",
                     "default": false,
                     "description": "If error color is disabled, indent colors will be rendered until the length of rendered characters (white spaces, tabs, and other ones) is divisible by tabsize. Turn on this option to render white spaces and tabs only."
+                },
+                "indentRainbow.indicatorStyle": {
+                    "type": "string",
+                    "default": "classic",
+                    "enum": ["classic", "light"],
+                    "markdownDescription": "Classic mode uses a full colored tab to indicate the indendation. Light mode will only display a colored border similar to the default indent guide lines. You can disable the default indicators with `#editor.guides.indentation#`."
+                },
+                "indentRainbow.lightIndicatorStyleLineWidth": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "This property defines the indent indicator lineWidth when using light mode."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,8 @@ export function activate(context: vscode.ExtensionContext) {
 
   const ignoreLinePatterns = vscode.workspace.getConfiguration('indentRainbow')['ignoreLinePatterns'] || [];
   const colorOnWhiteSpaceOnly = vscode.workspace.getConfiguration('indentRainbow')['colorOnWhiteSpaceOnly'] || false;
+  const indicatorStyle = vscode.workspace.getConfiguration('indentRainbow')['indicatorStyle'] || 'classic';
+  const lightIndicatorStyleLineWidth = vscode.workspace.getConfiguration('indentRainbow')['lightIndicatorStyleLineWidth'] || 1;
 
   // Colors will cycle through, and can be any size that you want
   const colors = vscode.workspace.getConfiguration('indentRainbow')['colors'] || [
@@ -40,9 +42,17 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Loops through colors and creates decoration types for each one
   colors.forEach((color, index) => {
-    decorationTypes[index] = vscode.window.createTextEditorDecorationType({
-      backgroundColor: color
-    });
+    if (indicatorStyle === 'classic') {
+      decorationTypes[index] = vscode.window.createTextEditorDecorationType({
+        backgroundColor: color
+      });
+    } else if (indicatorStyle === 'light') {
+      decorationTypes[index] = vscode.window.createTextEditorDecorationType({
+        borderStyle: "solid",
+        borderColor: color,
+        borderWidth: `0 0 0 ${lightIndicatorStyleLineWidth}px`
+      });
+    }
   });
 
   // loop through ignore regex strings and convert to valid RegEx's.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -268,4 +268,23 @@ export function activate(context: vscode.ExtensionContext) {
     tabmix_decoration_type && activeEditor.setDecorations(tabmix_decoration_type, tabmix_decorator);
     clearMe = true;
   }
+  /**
+   * Listen for configuration change in indentRainbow section
+   * When anything changes in the section, show a prompt to reload
+   * VSCode window 
+  */
+  vscode.workspace.onDidChangeConfiguration(configChangeEvent => {
+
+    if (configChangeEvent.affectsConfiguration('indentRainbow')) {
+      const actions = ['Reload now', 'Later'];
+
+      vscode.window
+        .showInformationMessage('The VSCode window needs to reload for the changes to take effect. Would you like to reload the window now?', ...actions)
+        .then(action => {
+          if (action === actions[0]) {
+            vscode.commands.executeCommand('workbench.action.reloadWindow');
+          }
+        });
+    }
+	});
 }


### PR DESCRIPTION
Hi, 

I thought it would be nice to have a  second, light,  style option to show the indent indicator just as a thin line. I implemented this by using a colored left border instead of the background fill. I added settings to configure this alternative setting and kept the original style as the default option.

<img width="156" alt="Screen Shot 2022-04-04 at 20 10 02" src="https://user-images.githubusercontent.com/9932295/161605332-042ff3a6-635b-4a51-9480-580db98b8401.png">
 