### PR TITLE
Add current scope highlight

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,11 @@
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "If enabled this will visually highlight the indent guide line for the current scope."
+                },
+                "indentRainbow.lightIndicatorStyleLineWidthHighlight": {
+                    "type": "number",
+                    "default": 2,
+                    "description": "This property defines the indent indicator lineWidth for the highlighted scope when using light mode."
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -96,6 +96,11 @@
                     "type": "number",
                     "default": 1,
                     "description": "This property defines the indent indicator lineWidth when using light mode."
+                },
+                "indentRainbow.highlightActiveScope": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "If enabled this will visually highlight the indent guide line for the current scope."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,9 +57,11 @@ export function activate(context: vscode.ExtensionContext) {
       });
     }
 
+    const updatedColor = color.replace(/[\d\.]+\)$/g, "1.0)");
+
     activeScopeLightDecorationTypes[index] = vscode.window.createTextEditorDecorationType({
       borderStyle: "solid",
-        borderColor: color,
+        borderColor: updatedColor,
         borderWidth: `0 0 0 ${lightIndicatorStyleLineWidth * 3}px`
       });
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
   const indicatorStyle = vscode.workspace.getConfiguration('indentRainbow')['indicatorStyle'] || 'classic';
   const highlightActiveScope = vscode.workspace.getConfiguration('indentRainbow')['highlightActiveScope'] || false;
   const lightIndicatorStyleLineWidth = vscode.workspace.getConfiguration('indentRainbow')['lightIndicatorStyleLineWidth'] || 1;
+  const lightIndicatorStyleLineWidthHighlight = vscode.workspace.getConfiguration('indentRainbow')['lightIndicatorStyleLineWidthHighlight'] || 2;
 
   // Colors will cycle through, and can be any size that you want
   const colors = vscode.workspace.getConfiguration('indentRainbow')['colors'] || [
@@ -74,7 +75,7 @@ export function activate(context: vscode.ExtensionContext) {
         activeScopeDecorationTypes[index] = vscode.window.createTextEditorDecorationType({
           borderStyle: "solid",
           borderColor: highlightColor,
-          borderWidth: `0 0 0 ${lightIndicatorStyleLineWidth * 3}px`
+          borderWidth: `0 0 0 ${lightIndicatorStyleLineWidthHighlight}px`
         });
       }
     }


### PR DESCRIPTION
Hi!

I felt like it would be a nice addition to have a subtle highlight on the current scope. I added an activeScopeDecorationType for both classic and light mode. Looking like this:

<img width="287" alt="Bildschirmfoto 2024-03-29 um 15 23 45" src="https://github.com/oderwat/vscode-indent-rainbow/assets/9932295/e6c25011-c4fe-4ae8-93e7-6aa9ffacbc1d">
<img width="281" alt="Bildschirmfoto 2024-03-29 um 15 24 31" src="https://github.com/oderwat/vscode-indent-rainbow/assets/9932295/c45b0909-7b10-49b4-bf86-d3c5d5283840">

I made this feature optional and added a setting to turn it on. (default setting is false)

<img width="540" alt="Bildschirmfoto 2024-03-29 um 15 30 24" src="https://github.com/oderwat/vscode-indent-rainbow/assets/9932295/5b47d32e-0357-457b-8f51-e9acd68cd9cc">

I also added a setting to set the line width of the highlighted indicator in light mode

<img width="667" alt="Bildschirmfoto 2024-03-29 um 15 30 12" src="https://github.com/oderwat/vscode-indent-rainbow/assets/9932295/bdae1c53-e576-4edf-b5a8-2d41f917bc04">

Grüße ☺️ (Greetings) and best regards!