### PR TITLE
Account for indentSize as well as tabSize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@types/glob": "^7.1.3",
                 "@types/mocha": "^8.0.4",
                 "@types/node": "^12.11.7",
-                "@types/vscode": "^1.52.0",
+                "@types/vscode": "^1.83.0",
                 "@typescript-eslint/eslint-plugin": "^4.11.1",
                 "@typescript-eslint/parser": "^4.11.1",
                 "eslint": "^7.16.0",
@@ -28,7 +28,7 @@
                 "webpack-cli": "^4.7.2"
             },
             "engines": {
-                "vscode": "^1.52.0"
+                "vscode": "^1.83.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -302,9 +302,9 @@
             "devOptional": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.60.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.60.0.tgz",
-            "integrity": "sha512-wZt3VTmzYrgZ0l/3QmEbCq4KAJ71K3/hmMQ/nfpv84oH8e81KKwPEoQ5v8dNCxfHFVJ1JabHKmCvqdYOoVm1Ow==",
+            "version": "1.83.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.83.0.tgz",
+            "integrity": "sha512-3mUtHqLAVz9hegut9au4xehuBrzRE3UJiQMpoEHkNl6XHliihO7eATx2BMHs0odsmmrwjJrlixx/Pte6M3ygDQ==",
             "dev": true
         },
         "node_modules/@types/yauzl": {
@@ -4985,9 +4985,9 @@
             "devOptional": true
         },
         "@types/vscode": {
-            "version": "1.60.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.60.0.tgz",
-            "integrity": "sha512-wZt3VTmzYrgZ0l/3QmEbCq4KAJ71K3/hmMQ/nfpv84oH8e81KKwPEoQ5v8dNCxfHFVJ1JabHKmCvqdYOoVm1Ow==",
+            "version": "1.83.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.83.0.tgz",
+            "integrity": "sha512-3mUtHqLAVz9hegut9au4xehuBrzRE3UJiQMpoEHkNl6XHliihO7eATx2BMHs0odsmmrwjJrlixx/Pte6M3ygDQ==",
             "dev": true
         },
         "@types/yauzl": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "icon": "assets/icon.png",
     "license": "MIT",
     "engines": {
-        "vscode": "^1.52.0"
+        "vscode": "^1.83.0"
     },
     "repository": {
         "url": "https://github.com/oderwat/vscode-indent-rainbow.git",
@@ -117,7 +117,7 @@
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.0.4",
         "@types/node": "^12.11.7",
-        "@types/vscode": "^1.52.0",
+        "@types/vscode": "^1.83.0",
         "@typescript-eslint/eslint-plugin": "^4.11.1",
         "@typescript-eslint/parser": "^4.11.1",
         "eslint": "^7.16.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,11 +164,9 @@ export function activate(context: vscode.ExtensionContext) {
     }
     var regEx = /^[\t ]+/gm;
     var text = activeEditor.document.getText();
-    var tabSizeRaw = activeEditor.options.tabSize;
-    var tabSize = 4
-    if(tabSizeRaw !== 'auto') {
-      tabSize=+tabSizeRaw
-    }
+    var indentSize = +(activeEditor.options.indentSize?? 4);
+    var tabSize = +(activeEditor.options.tabSize?? 4);
+
     var tabs = " ".repeat(tabSize);
     const ignoreLines = [];
     let error_decorator: vscode.DecorationOptions[] = [];
@@ -207,15 +205,15 @@ export function activate(context: vscode.ExtensionContext) {
       var ma = (match[0].replace(re, tabs)).length;
       /**
        * Error handling.
-       * When the indent spacing (as spaces) is not divisible by the tabsize,
+       * When the indent spacing (as spaces) is not divisible by the indentSize,
        * consider the indent incorrect and mark it with the error decorator.
        * Checks for lines being ignored in ignoreLines array ( `skip` Boolran)
        * before considering the line an error.
        */
-      if(!skip && ma % tabSize !== 0) {
+      if(!skip && ma % indentSize !== 0) {
         var startPos = activeEditor.document.positionAt(match.index);
         var endPos = activeEditor.document.positionAt(match.index + match[0].length);
-        var decoration = { range: new vscode.Range(startPos, endPos), hoverMessage: null };
+        var decoration = { range: new vscode.Range(startPos, endPos), hoverMessage: undefined };
         error_decorator.push(decoration);
       } else {
         var m = match[0];
@@ -225,16 +223,16 @@ export function activate(context: vscode.ExtensionContext) {
         while(n < l) {
           const s = n;
           var startPos = activeEditor.document.positionAt(match.index + n);
-          if(m[n] === "\t") {
-            n++;
+          if(m[Math.floor(n)] === "\t") {
+            n+=indentSize/tabSize;
           } else {
-            n+=tabSize;
+            n+=indentSize;
           }
           if (colorOnWhiteSpaceOnly && n > l) {
             n = l
           }
           var endPos = activeEditor.document.positionAt(match.index + n);
-          var decoration = { range: new vscode.Range(startPos, endPos), hoverMessage: null };
+          var decoration = { range: new vscode.Range(startPos, endPos), hoverMessage: undefined };
           var sc=0;
           var tc=0;
           if (!skip && tabmix_decorator) {


### PR DESCRIPTION
A few years ago vscode added the indentSize setting with a default = tabSize. 
This pull request updates the extension to: 
- look at indentSize rather than tabSize
- behave appropriately in cases where these are not equal
- depend on @types/vscode 1.83 rather than 1.52. 1.83 is the lowest version with indentSize.

An issue that is not solved by this pull request is partial colouring of tab characters, this can occur when indentSize % tabSize != 0. Instead tabs are coloured by their right most indent colour(this was tested with tabSize = 8 and indentSize =4). This behaviour seems good enough to me.

Let me know if anything else is needed before the PR can be accepted